### PR TITLE
fix: ensure all labels are strings

### DIFF
--- a/Albayzin2016/__init__.py
+++ b/Albayzin2016/__init__.py
@@ -104,7 +104,7 @@ class TVRadio(SpeakerDiarizationProtocol):
             uri = rttm['uri'].iloc[0]
             annotation = Annotation()
             for index, row in rttm.iterrows():
-                annotation[Segment(float(row['start']), float(row['start']) + float(row['duration']))] = row['label']
+                annotation[Segment(float(row['start']), float(row['start']) + float(row['duration']))] = str(row['label'])
             rttms[uri] = annotation
 
         #By default it take all the file time


### PR DESCRIPTION
Labels in "trn/session23.rttm" are all integers so `pd.read_table` automatically convert them to `int`. 
It is better if all labels in pyannote.database plugins are string, for consistency.